### PR TITLE
backporting python2

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,15 +1,23 @@
-FROM alpine:3.15
+FROM alpine:3.17
 
 LABEL version="1.0"
 LABEL maintainer="Hive Solutions <development@hive.pt>"
 
 RUN apk update &&\
-    apk add bash git ca-certificates python2 python3 &&\
+    apk add bash git ca-certificates python3 &&\
     wget "https://bootstrap.pypa.io/get-pip.py" &&\
-    wget "https://bootstrap.pypa.io/pip/2.7/get-pip.py" -O get-pip-2.py &&\
     python3 get-pip.py &&\
-    python get-pip-2.py &&\
-    rm get-pip.py &&\
-    rm get-pip-2.py
+    rm get-pip.py
+
+COPY bin-python.patch /root/bin-python.patch
+RUN apk add --virtual .alpine-sdk alpine-sdk &&\
+    git clone --depth 1 --branch v3.15.7 git://git.alpinelinux.org/aports ~/aports &&\
+    git -C ~/aports apply ~/bin-python.patch &&\
+    cd ~/aports/community/python2 && abuild-keygen -a -n && abuild -F -r && cd ~/ &&\
+    apk add --allow-untrusted ~/packages/community/x86_64/python2-2.7.18-r4.apk &&\
+    wget "https://bootstrap.pypa.io/pip/2.7/get-pip.py" -O get-pip-2.py &&\
+    python2 ~/get-pip-2.py &&\
+    rm -r ~/aports ~/packages ~/bin-python.patch ~/get-pip-2.py &&\
+    apk del .alpine-sdk
 
 CMD ["/bin/bash"]

--- a/alpine/bin-python.patch
+++ b/alpine/bin-python.patch
@@ -1,0 +1,15 @@
+diff --git a/community/python2/APKBUILD b/community/python2/APKBUILD
+index fc83fccc..579f3c4a 100644
+--- a/community/python2/APKBUILD
++++ b/community/python2/APKBUILD
+@@ -95,9 +95,7 @@ package() {
+ 	install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
+ 	rm "$pkgdir/usr/bin/2to3"
+ 
+-	# This symlink should be owned by python3 but due to lots of packages
+-	# wanting it to be python2, leave it as is
+-	# rm -f "$pkgdir"/usr/bin/python
++	rm -f "$pkgdir"/usr/bin/python
+ }
+ 
+ _mv_files() {


### PR DESCRIPTION
`/usr/bin/python` is now owned by `python3`: https://git.alpinelinux.org/aports/tree/main/python3/APKBUILD?h=3.17-stable#n199