### PR TITLE
feat: adding build and push multi arch images through github actions

### DIFF
--- a/.github/workflows/dockerx_alpine.yml
+++ b/.github/workflows/dockerx_alpine.yml
@@ -41,4 +41,4 @@ jobs:
           file: ${{ matrix.config.dockerfile }}
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
           push: true
-          tags: hivesolutions/${{ matrix.config.image_name }}:${{ steps.set_tag.outputs.tag }}
+          tags: hugoagomes/${{ matrix.config.image_name }}:${{ steps.set_tag.outputs.tag }}

--- a/.github/workflows/dockerx_alpine.yml
+++ b/.github/workflows/dockerx_alpine.yml
@@ -1,8 +1,8 @@
 name: Build and Push Alpine Images
 on:
   push:
-    branches:
-      - master
+    branches-ignore:
+      - none
     paths:
       - "alpine/**"
       - "alpine_dev/**"
@@ -26,6 +26,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set tag name based on branch
+        id: set_tag
+        run: |
+          if [[ "${{ github.ref_name }}" == "master" ]]; then
+            echo "::set-output name=tag::latest"
+          else
+            echo "::set-output name=tag::${{ github.ref_name }}"
+          fi
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -33,4 +41,4 @@ jobs:
           file: ${{ matrix.config.dockerfile }}
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
           push: true
-          tags: hivesolutions/${{ matrix.config.image_name }}:latest
+          tags: hivesolutions/${{ matrix.config.image_name }}:${{ steps.set_tag.outputs.tag }}

--- a/.github/workflows/dockerx_alpine.yml
+++ b/.github/workflows/dockerx_alpine.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     strategy:
       fail-fast: false
       matrix:
@@ -41,4 +41,4 @@ jobs:
           file: ${{ matrix.config.dockerfile }}
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
           push: true
-          tags: hugoagomes/${{ matrix.config.image_name }}:${{ steps.set_tag.outputs.tag }}
+          tags: hivesolutions/${{ matrix.config.image_name }}:${{ steps.set_tag.outputs.tag }}

--- a/.github/workflows/dockerx_alpine.yml
+++ b/.github/workflows/dockerx_alpine.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dockerx_alpine.yml
+++ b/.github/workflows/dockerx_alpine.yml
@@ -1,0 +1,36 @@
+name: Build and Push Alpine Images
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "alpine/**"
+      - "alpine_dev/**"
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { dockerfile: "alpine/Dockerfile", context: "alpine", image_name: "alpine" }
+          - { dockerfile: "alpine_dev/Dockerfile", context: "alpine_dev", image_name: "alpine_dev" }
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.config.context }}
+          file: ${{ matrix.config.dockerfile }}
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
+          push: true
+          tags: hivesolutions/${{ matrix.config.image_name }}:latest

--- a/.github/workflows/dockerx_python.yml
+++ b/.github/workflows/dockerx_python.yml
@@ -34,4 +34,4 @@ jobs:
           file: ./python/Dockerfile
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
           push: true
-          tags: hivesolutions/python:${{ steps.set_tag.outputs.tag }}
+          tags: hugoagomes/python:${{ steps.set_tag.outputs.tag }}

--- a/.github/workflows/dockerx_python.yml
+++ b/.github/workflows/dockerx_python.yml
@@ -1,0 +1,29 @@
+name: Build and Push Python Images
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "python/**"
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./python/Dockerfile
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
+          push: true
+          tags: hivesolutions/python:latest

--- a/.github/workflows/dockerx_python.yml
+++ b/.github/workflows/dockerx_python.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -34,4 +34,4 @@ jobs:
           file: ./python/Dockerfile
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
           push: true
-          tags: hugoagomes/python:${{ steps.set_tag.outputs.tag }}
+          tags: hivesolutions/python:${{ steps.set_tag.outputs.tag }}

--- a/.github/workflows/dockerx_python.yml
+++ b/.github/workflows/dockerx_python.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/dockerx_python.yml
+++ b/.github/workflows/dockerx_python.yml
@@ -1,8 +1,8 @@
 name: Build and Push Python Images
 on:
   push:
-    branches:
-      - master
+    branches-ignore:
+      - none
     paths:
       - "python/**"
   workflow_dispatch:
@@ -19,6 +19,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set tag name based on branch
+        id: set_tag
+        run: |
+          if [[ "${{ github.ref_name }}" == "master" ]]; then
+            echo "::set-output name=tag::latest"
+          else
+            echo "::set-output name=tag::${{ github.ref_name }}"
+          fi
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -26,4 +34,4 @@ jobs:
           file: ./python/Dockerfile
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
           push: true
-          tags: hivesolutions/python:latest
+          tags: hivesolutions/python:${{ steps.set_tag.outputs.tag }}


### PR DESCRIPTION
To automatically initiate a new build upon an update to the base image, one could integrate a dispatch event that activates the respective GitHub Actions workflow. 

The middleware in place efficiently queries updates by interfacing with the Docker Hub Registry API - something around these lines:

```typescript
import { axiod } from "./deps.ts";

const CHECK_INTERVAL = 3600000;
const PERSONAL_ACCESS_TOKEN = "TOKEN";

let lastKnownTag: string | null = null;

async function checkForUpdates() {
  try {
    const response = await axiod.get(
      "https://hub.docker.com/v2/repositories/library/alpine/tags?page_size=1"
    );
    const latestTag = response.data.results[0].tag_last_pushed;

    if (lastKnownTag !== latestTag) {
      if (!lastKnownTag) {
        return;
      }
      await triggerGitHubActions();

      lastKnownTag = latestTag;
    }
  } catch (error) {
    console.error("Error checking DockerHub API:", error);
  }
}

async function triggerGitHubActions() {
  try {
    await axiod.post(
      "https://api.github.com/repos/hivesolutions/docker/dispatches",
      {
        event_type: "base-image-dispatch",
      },
      {
        headers: {
          Accept: "application/vnd.github.everest-preview+json",
          Authorization: `Bearer ${PERSONAL_ACCESS_TOKEN}`,
        },
      }
    );
  } catch (error) {
    console.error("Error triggering hivesolutions/docker's base-image-dispatch:", error);
  }
}

checkForUpdates();
setInterval(checkForUpdates, CHECK_INTERVAL);
```