### PR TITLE
feat: adding qemu_rpi image

### DIFF
--- a/.github/workflows/dockerx_qemu_rpi.yml
+++ b/.github/workflows/dockerx_qemu_rpi.yml
@@ -1,0 +1,40 @@
+name: Build and Push QEMU RPi Images
+on:
+  push:
+    branches-ignore:
+      - none
+    paths:
+      - "qemu_rpi/**"
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: self-hosted
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set tag name based on branch
+        id: set_tag
+        run: |
+          if [[ "${{ github.ref_name }}" == "master" ]]; then
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          else
+            GITHUB_REFNAME=${{ github.ref_name }}
+            BRANCH_NAME=${GITHUB_REFNAME//\//_}
+            echo "tag=latest-$BRANCH_NAME" >> $GITHUB_OUTPUT
+          fi
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: "qemu_rpi"
+          file: "qemu_rpi/Dockerfile"
+          platforms: linux/amd64,linux/arm64/v8
+          push: true
+          tags: hivesolutions/qemu_rpi:${{ steps.set_tag.outputs.tag }}

--- a/.github/workflows/dockerx_qemu_rpi.yml
+++ b/.github/workflows/dockerx_qemu_rpi.yml
@@ -1,4 +1,4 @@
-name: Build and Push QEMU RPi Images
+name: Build and Push QEMU RPi Image
 on:
   push:
     branches-ignore:

--- a/qemu_rpi/Dockerfile
+++ b/qemu_rpi/Dockerfile
@@ -17,11 +17,12 @@ EXPOSE 2222
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+WORKDIR /qemu
+
 RUN apt-get update -y &&\
     apt-get install -y fdisk mtools openssl python3-minimal qemu-system-aarch64 wget xz-utils
 
-WORKDIR /qemu
-
+# Downloading RPi image and validating its checksum
 RUN wget "${RPI_IMAGE_URL}" -O "${RPI_IMAGE_FILE}.xz" &&\
     echo "${RPI_IMAGE_SHA512}  ${RPI_IMAGE_FILE}.xz" | sha256sum -c - &&\
     xz -d ${RPI_IMAGE_FILE}.xz

--- a/qemu_rpi/Dockerfile
+++ b/qemu_rpi/Dockerfile
@@ -1,11 +1,11 @@
 FROM debian:bookworm-slim
 
+ARG USERNAME=pi
+ARG PASSWORD=raspberry
+
 ARG RPI_IMAGE_URL=https://downloads.raspberrypi.org/raspios_arm64/images/raspios_arm64-2023-05-03/2023-05-03-raspios-bullseye-arm64.img.xz
 ARG RPI_IMAGE_SHA512=e7c0c89db32d457298fbe93195e9d11e3e6b4eb9e0683a7beb1598ea39a0a7aa
 ARG RPI_IMAGE_FILE=2023-05-03-raspios-bullseye-arm64.img
-
-ARG USERNAME=pi
-ARG PASSWORD=raspberry
 
 ENV QEMU_MACHINE raspi3b
 ENV QEMU_DTB bcm2710-rpi-3-b-plus.dtb
@@ -40,7 +40,7 @@ RUN SECTOR_SIZE=$(fdisk -lu ${RPI_IMAGE_FILE} | awk '/Sector size/ {print $4}') 
 
 # Creating user and activating ssh
 RUN mkdir -p /tmp && touch /tmp/ssh && \
-    echo "${USERNAME}:`openssl passwd -6 ${PASSWORD}}`" | tee /tmp/userconf &&\
+    echo "${USERNAME}:`openssl passwd -6 ${PASSWORD}`" | tee /tmp/userconf &&\
     mcopy /tmp/ssh x:/ && mcopy /tmp/userconf x:/
 
 # Cleaning up

--- a/qemu_rpi/Dockerfile
+++ b/qemu_rpi/Dockerfile
@@ -1,11 +1,11 @@
 FROM debian:bookworm-slim
 
-ARG USERNAME pi
-ARG PASSWORD raspberry
+ARG USERNAME=pi
+ARG PASSWORD=raspberry
 
-ARG RPI_IMAGE_URL https://downloads.raspberrypi.org/raspios_arm64/images/raspios_arm64-2023-05-03/2023-05-03-raspios-bullseye-arm64.img.xz
-ARG RPI_IMAGE_SHA512 e7c0c89db32d457298fbe93195e9d11e3e6b4eb9e0683a7beb1598ea39a0a7aa
-ARG RPI_IMAGE_FILE 2023-05-03-raspios-bullseye-arm64.img
+ARG RPI_IMAGE_URL=https://downloads.raspberrypi.org/raspios_arm64/images/raspios_arm64-2023-05-03/2023-05-03-raspios-bullseye-arm64.img.xz
+ARG RPI_IMAGE_SHA512?e7c0c89db32d457298fbe93195e9d11e3e6b4eb9e0683a7beb1598ea39a0a7aa
+ARG RPI_IMAGE_FILE=2023-05-03-raspios-bullseye-arm64.img
 
 ENV QEMU_MACHINE raspi3b
 ENV QEMU_DTB bcm2710-rpi-3-b-plus.dtb

--- a/qemu_rpi/Dockerfile
+++ b/qemu_rpi/Dockerfile
@@ -4,7 +4,7 @@ ARG USERNAME=pi
 ARG PASSWORD=raspberry
 
 ARG RPI_IMAGE_URL=https://downloads.raspberrypi.org/raspios_arm64/images/raspios_arm64-2023-05-03/2023-05-03-raspios-bullseye-arm64.img.xz
-ARG RPI_IMAGE_SHA512?e7c0c89db32d457298fbe93195e9d11e3e6b4eb9e0683a7beb1598ea39a0a7aa
+ARG RPI_IMAGE_SHA512=e7c0c89db32d457298fbe93195e9d11e3e6b4eb9e0683a7beb1598ea39a0a7aa
 ARG RPI_IMAGE_FILE=2023-05-03-raspios-bullseye-arm64.img
 
 ENV QEMU_MACHINE raspi3b

--- a/qemu_rpi/Dockerfile
+++ b/qemu_rpi/Dockerfile
@@ -39,8 +39,8 @@ RUN SECTOR_SIZE=$(fdisk -lu ${RPI_IMAGE_FILE} | awk '/Sector size/ {print $4}') 
     mcopy x:/${QEMU_DTB} . && mcopy x:/kernel8.img .
 
 # Creating user and activating ssh
-RUN mkdir -p /tmp && touch /tmp/ssh && \
-    PASSWORD=`openssl passwd -6 ${PASSWORD}` && \
+RUN mkdir -p /tmp && touch /tmp/ssh &&\
+    PASSWORD=`openssl passwd -6 ${PASSWORD}` &&\
     echo "${USERNAME}:${PASSWORD}" | tee /tmp/userconf &&\
     mcopy /tmp/ssh x:/ && mcopy /tmp/userconf x:/
 

--- a/qemu_rpi/Dockerfile
+++ b/qemu_rpi/Dockerfile
@@ -58,5 +58,5 @@ ENTRYPOINT qemu-system-aarch64 \
     -kernel kernel8.img \
     -nographic \
     -append "rw earlyprintk loglevel=8 console=ttyAMA0,115200 dwc_otg.lpm_enable=0 root=/dev/mmcblk0p2 rootdelay=1" \
-    -device usb-net,netdev=ulan,mac=02:ca:fe:f0:0d:01 \
+    -device usb-net,netdev=ulan,mac=b8:27:eb:4f:15:95 \
     -netdev user,id=ulan,hostfwd=tcp::2222-:22

--- a/qemu_rpi/Dockerfile
+++ b/qemu_rpi/Dockerfile
@@ -40,7 +40,8 @@ RUN SECTOR_SIZE=$(fdisk -lu ${RPI_IMAGE_FILE} | awk '/Sector size/ {print $4}') 
 
 # Creating user and activating ssh
 RUN mkdir -p /tmp && touch /tmp/ssh && \
-    echo "${USERNAME}:`openssl passwd -6 ${PASSWORD}`" | tee /tmp/userconf &&\
+    PASSWORD=`openssl passwd -6 ${PASSWORD}` && \
+    echo "${USERNAME}:${PASSWORD}" | tee /tmp/userconf &&\
     mcopy /tmp/ssh x:/ && mcopy /tmp/userconf x:/
 
 # Cleaning up

--- a/qemu_rpi/Dockerfile
+++ b/qemu_rpi/Dockerfile
@@ -1,13 +1,11 @@
 FROM debian:bookworm-slim
 
+ARG RPI_IMAGE_URL=https://downloads.raspberrypi.org/raspios_arm64/images/raspios_arm64-2023-05-03/2023-05-03-raspios-bullseye-arm64.img.xz
+ARG RPI_IMAGE_SHA512=e7c0c89db32d457298fbe93195e9d11e3e6b4eb9e0683a7beb1598ea39a0a7aa
+ARG RPI_IMAGE_FILE=2023-05-03-raspios-bullseye-arm64.img
+
 ARG USERNAME=pi
 ARG PASSWORD=raspberry
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-ENV RPI_IMAGE_URL=https://downloads.raspberrypi.org/raspios_arm64/images/raspios_arm64-2023-05-03/2023-05-03-raspios-bullseye-arm64.img.xz
-ENV RPI_IMAGE_SHA512=e7c0c89db32d457298fbe93195e9d11e3e6b4eb9e0683a7beb1598ea39a0a7aa
-ENV RPI_IMAGE_FILE=2023-05-03-raspios-bullseye-arm64.img
 
 ENV QEMU_MACHINE raspi3b
 ENV QEMU_DTB bcm2710-rpi-3-b-plus.dtb
@@ -16,6 +14,8 @@ ENV QEMU_MEM 1G
 ENV QEMU_CORES 4
 
 EXPOSE 2222
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y &&\
     apt-get install -y fdisk mtools openssl python3-minimal qemu-system-aarch64 wget xz-utils

--- a/qemu_rpi/Dockerfile
+++ b/qemu_rpi/Dockerfile
@@ -1,11 +1,11 @@
 FROM debian:bookworm-slim
 
-ARG USERNAME=pi
-ARG PASSWORD=raspberry
+ARG USERNAME pi
+ARG PASSWORD raspberry
 
-ARG RPI_IMAGE_URL=https://downloads.raspberrypi.org/raspios_arm64/images/raspios_arm64-2023-05-03/2023-05-03-raspios-bullseye-arm64.img.xz
-ARG RPI_IMAGE_SHA512=e7c0c89db32d457298fbe93195e9d11e3e6b4eb9e0683a7beb1598ea39a0a7aa
-ARG RPI_IMAGE_FILE=2023-05-03-raspios-bullseye-arm64.img
+ARG RPI_IMAGE_URL https://downloads.raspberrypi.org/raspios_arm64/images/raspios_arm64-2023-05-03/2023-05-03-raspios-bullseye-arm64.img.xz
+ARG RPI_IMAGE_SHA512 e7c0c89db32d457298fbe93195e9d11e3e6b4eb9e0683a7beb1598ea39a0a7aa
+ARG RPI_IMAGE_FILE 2023-05-03-raspios-bullseye-arm64.img
 
 ENV QEMU_MACHINE raspi3b
 ENV QEMU_DTB bcm2710-rpi-3-b-plus.dtb

--- a/qemu_rpi/Dockerfile
+++ b/qemu_rpi/Dockerfile
@@ -1,0 +1,61 @@
+FROM debian:bookworm-slim
+
+ARG USERNAME=pi
+ARG PASSWORD=raspberry
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ENV RPI_IMAGE_URL=https://downloads.raspberrypi.org/raspios_arm64/images/raspios_arm64-2023-05-03/2023-05-03-raspios-bullseye-arm64.img.xz
+ENV RPI_IMAGE_SHA512=e7c0c89db32d457298fbe93195e9d11e3e6b4eb9e0683a7beb1598ea39a0a7aa
+ENV RPI_IMAGE_FILE=2023-05-03-raspios-bullseye-arm64.img
+
+ENV QEMU_MACHINE raspi3b
+ENV QEMU_DTB bcm2710-rpi-3-b-plus.dtb
+ENV QEMU_CPU cortex-a72
+ENV QEMU_MEM 1G
+ENV QEMU_CORES 4
+
+EXPOSE 2222
+
+RUN apt-get update -y &&\
+    apt-get install -y fdisk mtools openssl python3-minimal qemu-system-aarch64 wget xz-utils
+
+WORKDIR /qemu
+
+RUN wget "${RPI_IMAGE_URL}" -O "${RPI_IMAGE_FILE}.xz" &&\
+    echo "${RPI_IMAGE_SHA512}  ${RPI_IMAGE_FILE}.xz" | sha256sum -c - &&\
+    xz -d ${RPI_IMAGE_FILE}.xz
+
+# Resizing the image to the next power of two as required by QEMU
+RUN RPI_IMAGE_SIZE=$(stat -c%s "${RPI_IMAGE_FILE}") &&\
+    NEXT_POWER_OF_TWO=$(python3 -c "import math; print(2 ** math.ceil(math.log(int(${RPI_IMAGE_SIZE}), 2)))") &&\
+    qemu-img resize "${RPI_IMAGE_FILE}" "${NEXT_POWER_OF_TWO}"
+
+# Extracting kernel and device tree files
+RUN SECTOR_SIZE=$(fdisk -lu ${RPI_IMAGE_FILE} | awk '/Sector size/ {print $4}') &&\
+    SECTOR_START=$(fdisk -lu ${RPI_IMAGE_FILE} | awk '/W95 FAT32/ {print $2}') &&\
+    OFFSET=$((${SECTOR_SIZE}*${SECTOR_START})) &&\
+    echo "drive x: file=\"${RPI_IMAGE_FILE}\" offset=${OFFSET}" > ~/.mtoolsrc &&\
+    mcopy x:/${QEMU_DTB} . && mcopy x:/kernel8.img .
+
+# Creating user and activating ssh
+RUN mkdir -p /tmp && touch /tmp/ssh && \
+    echo "${USERNAME}:`openssl passwd -6 ${PASSWORD}}`" | tee /tmp/userconf &&\
+    mcopy /tmp/ssh x:/ && mcopy /tmp/userconf x:/
+
+# Cleaning up
+RUN apt-get autoremove -y && apt-get clean &&\
+    rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/apt
+
+ENTRYPOINT qemu-system-aarch64 \
+    -machine ${QEMU_MACHINE} \
+    -dtb ${QEMU_DTB} \
+    -cpu ${QEMU_CPU} \
+    -smp ${QEMU_CORES} \
+    -m ${QEMU_MEM} \
+    -sd ${RPI_IMAGE_FILE} \
+    -kernel kernel8.img \
+    -nographic \
+    -append "rw earlyprintk loglevel=8 console=ttyAMA0,115200 dwc_otg.lpm_enable=0 root=/dev/mmcblk0p2 rootdelay=1" \
+    -device usb-net,netdev=ulan,mac=02:ca:fe:f0:0d:01 \
+    -netdev user,id=ulan,hostfwd=tcp::2222-:22


### PR DESCRIPTION
```
root@debian-16gb-nbg1-1:/mnt/image# docker run -it -p 2222:2222 qemu_rpi

(...)
[  OK  ] Started System Logging Service.
[  OK  ] Started triggerhappy global hotkey daemon.
[  OK  ] Finished Remove Stale Onli…ext4 Metadata Check Snapshots.
[  OK  ] Finished Check for v3d driver.
[  OK  ] Finished dphys-swapfile - …mount, and delete a swap file.
[  OK  ] Finished Check for glamor.
[  OK  ] Started DHCP Client Daemon.
[  OK  ] Started LSB: Switch to ond…(unless shift key is pressed).
[  OK  ] Started Avahi mDNS/DNS-SD Stack.
[  OK  ] Started Authorization Manager.
[  OK  ] Started WPA supplicant.
[  OK  ] Started User Login Management.
[  OK  ] Reached target Network.
[  OK  ] Listening on Load/Save RF …itch Status /dev/rfkill Watch.
         Starting Modem Manager...
         Starting CUPS Scheduler...
         Starting /etc/rc.local Compatibility...
         Starting Permit User Sessions...
[  OK  ] Started LSB: rng-tools (Debian variant).
[  OK  ] Started /etc/rc.local Compatibility.
[  OK  ] Finished Permit User Sessions.
         Starting Hold until boot process finishes up...
         Starting User configuration dialog...
[  OK  ] Started CUPS Scheduler.
[  OK  ] Started LSB: Resize the ro… filesystem to fill partition.
[  OK  ] Finished Regenerate SSH host keys.
[  OK  ] Started Disk Manager.
[  OK  ] Started Modem Manager.
[  OK  ] Started Make remote CUPS printers available locally.
         Starting Turn on SSH if /boot/ssh is present...
         Starting OpenBSD Secure Shell server...
[  OK  ] Created slice system-getty.slice.
[  OK  ] Finished User configuration dialog.
         Starting Light Display Manager...
[  OK  ] Started OpenBSD Secure Shell server.
[  OK  ] Finished Turn on SSH if /boot/ssh is present.

Debian GNU/Linux 11 raspberrypi ttyAMA0

raspberrypi login: 
```